### PR TITLE
Add lavapipe CI tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,8 @@ jobs:
 
     - name: Install Vulkan SDK
       uses: jakoch/install-vulkan-sdk-action@v1.4.0
+      with:
+        install_lavapipe: true
     
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,13 @@ jobs:
       uses: jakoch/install-vulkan-sdk-action@v1.5.1
       with:
         install_lavapipe: true
-    
+
+    - name: Install Lavapipe
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y mesa-vulkan-drivers
+        echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> $GITHUB_ENV
+
     - name: Build
       run: cargo build --verbose
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,13 +26,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y mesa-vulkan-drivers
-        echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> $GITHUB_ENV
-
-    - name: Debug Vulkan
-      run: |
-        find /usr/share/vulkan -name "*.json" 2>/dev/null
-        echo "VK_ICD_FILENAMES=$VK_ICD_FILENAMES"
-        vulkaninfo --summary 2>&1 || true
+        echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json" >> $GITHUB_ENV
 
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,12 @@ jobs:
         sudo apt-get install -y mesa-vulkan-drivers
         echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> $GITHUB_ENV
 
+    - name: Debug Vulkan
+      run: |
+        find /usr/share/vulkan -name "*.json" 2>/dev/null
+        echo "VK_ICD_FILENAMES=$VK_ICD_FILENAMES"
+        vulkaninfo --summary 2>&1 || true
+
     - name: Build
       run: cargo build --verbose
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Vulkan SDK
-      uses: jakoch/install-vulkan-sdk-action@v1.4.0
+      uses: jakoch/install-vulkan-sdk-action@v1.5.1
       with:
         install_lavapipe: true
     

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,12 @@
         rustToolchain = pkgs.rust-bin.stable."1.92.0".default.override {
           extensions = [ "rust-src" "clippy" "rustfmt" ];
         };
+        swiftshader = pkgs.swiftshader.overrideAttrs (old: {
+          postPatch = (old.postPatch or "") + ''
+            sed -i '1s/^/#include <cstdint>\n/' \
+              third_party/glslang/SPIRV/SpvBuilder.h
+          '';
+        });
       in
       {
         devShells.default = pkgs.mkShell {
@@ -37,6 +43,7 @@
 			glslang
 			spirv-tools
 			shaderc
+            mesa # for lavapipe
 
 			# Wayland
 			wayland

--- a/src/graphics/renderer.rs
+++ b/src/graphics/renderer.rs
@@ -41,7 +41,7 @@ pub struct Renderer {
 impl Renderer {
     pub fn new(window: &WindowState, proxy: EventLoopProxy<UserEvent>, vsync: bool) -> Renderer {
         let entry = ash::Entry::linked();
-        let instance = Instance::new(&entry, window);
+        let instance = Instance::new(&entry, Some(window));
         let surface = Surface::new(&entry, &instance, window);
         let (physical_device, queue_family_index) = instance.create_physical_device(&entry, &surface);
         let device = Device::new(&instance, physical_device, queue_family_index);

--- a/src/vulkan/device.rs
+++ b/src/vulkan/device.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use ash::khr::swapchain;
-use ash::{vk, Entry};
+use ash::{vk};
 use ash::vk::{PipelineStageFlags, Queue};
 use log::trace;
 use crate::vulkan::{CommandBuffer, Instance, LOG_TARGET};
@@ -187,7 +187,8 @@ impl Device {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::ash::Entry;
+use super::*;
 
     #[test]
     fn create_logical_device() {

--- a/src/vulkan/device.rs
+++ b/src/vulkan/device.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use ash::khr::swapchain;
-use ash::vk;
+use ash::{vk, Entry};
 use ash::vk::{PipelineStageFlags, Queue};
 use log::trace;
 use crate::vulkan::{CommandBuffer, Instance, LOG_TARGET};
@@ -183,4 +183,18 @@ impl Device {
             inner: self.inner.clone(),
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_logical_device() {
+        let entry = Entry::linked();
+        let instance = Instance::new(&entry, None);
+        let (physical_device, queue_family_index) = instance.create_physical_device_headless();
+        let _device = Device::new(&instance, physical_device, queue_family_index);
+    }
+
 }

--- a/src/vulkan/instance.rs
+++ b/src/vulkan/instance.rs
@@ -1,7 +1,7 @@
-use ash::ext::debug_utils;
+use ash::ext::{debug_utils, headless_surface};
 use ash::{Entry, vk};
 use ash::vk::{DebugUtilsMessengerEXT, PhysicalDevice};
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, CStr, CString};
 use std::os::raw::c_void;
 use std::{ptr, vec};
 use std::sync::Arc;
@@ -62,7 +62,7 @@ pub struct Instance {
 
 impl Instance {
 
-    pub fn new(entry: &Entry, window: &WindowState) -> Self {
+    pub fn new(entry: &Entry, window: Option<&WindowState>) -> Self {
         let app_name = CString::new("cen").unwrap();
         let engine_name = CString::new("Cen").unwrap();
         let app_info = vk::ApplicationInfo::default()
@@ -72,10 +72,21 @@ impl Instance {
             .api_version(vk::make_api_version(0, 1, 2, 0))
             .application_name(app_name.as_c_str());
 
-        let mut extension_names =
-            ash_window::enumerate_required_extensions(window.display_handle.as_raw())
-                .unwrap()
-                .to_vec();
+        let mut extension_names: Vec<*const c_char> = vec![];
+        if let Some(window) = window {
+            extension_names.extend_from_slice(ash_window::enumerate_required_extensions(window.display_handle.as_raw()).unwrap());
+        } else {
+            // Add headless extension
+            let available_extensions = unsafe { entry.enumerate_instance_extension_properties(None) }.unwrap();
+            let headless_supported = available_extensions.iter().any(|e| {
+                e.extension_name_as_c_str() == Ok(headless_surface::NAME)
+            });
+            if headless_supported {
+                extension_names.push(headless_surface::NAME.as_ptr());
+            } else {
+                panic!("Using a headless driver without headless support")
+            }
+        }
         extension_names.push(debug_utils::NAME.as_ptr());
         extension_names.push(ash::khr::get_physical_device_properties2::NAME.as_ptr());
 
@@ -145,7 +156,7 @@ impl Instance {
         let instance_inner = InstanceInner {
             instance,
             debug_utils,
-            debug_utils_messenger,
+            debug_utils_messenger
         };
 
         Self {
@@ -168,13 +179,25 @@ impl Instance {
                         .iter()
                         .enumerate()
                         .find_map(|(index, info)| {
+                            let device_type = unsafe {
+                                let props = self.handle().get_physical_device_properties(*physical_device);
+                                props.device_type
+                            };
+
+                            if device_type == vk::PhysicalDeviceType::CPU {
+                                // Accept cpu renderers
+                                return Some((*physical_device, index));
+                            }
+
+                            // The following call crashes on cpu devices
                             let supports_graphics_and_surface =
-                                info.queue_flags.contains(vk::QueueFlags::GRAPHICS)
-                                && surface_loader.get_physical_device_surface_support(
-                                    *physical_device,
-                                    index as u32,
-                                    *surface.handle()
-                                ).unwrap();
+                                unsafe {
+                                    surface_loader.get_physical_device_surface_support(
+                                        *physical_device,
+                                        index as u32,
+                                        *surface.handle()
+                                    ).expect("error")
+                                };
                             if supports_graphics_and_surface {
                                 Some((*physical_device, index))
                             } else {
@@ -191,5 +214,16 @@ impl Instance {
         &self.inner.instance
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_headless_instance() {
+        let entry = Entry::linked();
+        let _instance = Instance::new(&entry, None);
+    }
 }
 

--- a/src/vulkan/instance.rs
+++ b/src/vulkan/instance.rs
@@ -1,4 +1,4 @@
-use ash::ext::{debug_utils, headless_surface};
+use ash::ext::{debug_utils};
 use ash::{Entry, vk};
 use ash::vk::{DebugUtilsMessengerEXT, PhysicalDevice};
 use std::ffi::{c_char, CStr, CString};
@@ -75,17 +75,6 @@ impl Instance {
         let mut extension_names: Vec<*const c_char> = vec![];
         if let Some(window) = window {
             extension_names.extend_from_slice(ash_window::enumerate_required_extensions(window.display_handle.as_raw()).unwrap());
-        } else {
-            // Add headless extension
-            let available_extensions = unsafe { entry.enumerate_instance_extension_properties(None) }.unwrap();
-            let headless_supported = available_extensions.iter().any(|e| {
-                e.extension_name_as_c_str() == Ok(headless_surface::NAME)
-            });
-            if headless_supported {
-                extension_names.push(headless_surface::NAME.as_ptr());
-            } else {
-                panic!("Using a headless driver without headless support")
-            }
         }
         extension_names.push(debug_utils::NAME.as_ptr());
         extension_names.push(ash::khr::get_physical_device_properties2::NAME.as_ptr());
@@ -178,11 +167,8 @@ impl Instance {
                     self.handle().get_physical_device_queue_family_properties(*physical_device)
                         .iter()
                         .enumerate()
-                        .find_map(|(index, info)| {
-                            let device_type = unsafe {
-                                let props = self.handle().get_physical_device_properties(*physical_device);
-                                props.device_type
-                            };
+                        .find_map(|(index, _info)| {
+                            let device_type = self.handle().get_physical_device_properties(*physical_device).device_type;
 
                             if device_type == vk::PhysicalDeviceType::CPU {
                                 // Accept cpu renderers
@@ -191,13 +177,11 @@ impl Instance {
 
                             // The following call crashes on cpu devices
                             let supports_graphics_and_surface =
-                                unsafe {
-                                    surface_loader.get_physical_device_surface_support(
-                                        *physical_device,
-                                        index as u32,
-                                        *surface.handle()
-                                    ).expect("error")
-                                };
+                                surface_loader.get_physical_device_surface_support(
+                                    *physical_device,
+                                    index as u32,
+                                    *surface.handle()
+                                ).expect("error");
                             if supports_graphics_and_surface {
                                 Some((*physical_device, index))
                             } else {

--- a/src/vulkan/instance.rs
+++ b/src/vulkan/instance.rs
@@ -153,6 +153,35 @@ impl Instance {
         }
     }
 
+    pub fn create_physical_device_headless(&self) -> (PhysicalDevice, u32) {
+        let physical_devices = unsafe {
+            self.handle()
+                .enumerate_physical_devices()
+                .expect("Failed to enumerate physical devices.")
+        };
+        let (physical_device, queue_family_index) = physical_devices
+            .iter()
+            .find_map(|physical_device| {
+                unsafe {
+                    self.handle().get_physical_device_queue_family_properties(*physical_device)
+                        .iter()
+                        .enumerate()
+                        .find_map(|(index, _info)| {
+
+                            let device_type = self.handle().get_physical_device_properties(*physical_device).device_type;
+                            if device_type == vk::PhysicalDeviceType::CPU {
+                                // Accept cpu renderers
+                                return Some((*physical_device, index));
+                            }
+
+                            None
+                        })
+                }
+            })
+            .expect("Couldn't find a suitable device.");
+        (physical_device, queue_family_index as u32)
+    }
+
     pub fn create_physical_device(&self, entry: &Entry, surface: &Surface) -> (PhysicalDevice, u32) {
         let physical_devices = unsafe {
             self.handle()
@@ -168,14 +197,6 @@ impl Instance {
                         .iter()
                         .enumerate()
                         .find_map(|(index, _info)| {
-                            let device_type = self.handle().get_physical_device_properties(*physical_device).device_type;
-
-                            if device_type == vk::PhysicalDeviceType::CPU {
-                                // Accept cpu renderers
-                                return Some((*physical_device, index));
-                            }
-
-                            // The following call crashes on cpu devices
                             let supports_graphics_and_surface =
                                 surface_loader.get_physical_device_surface_support(
                                     *physical_device,
@@ -208,6 +229,13 @@ mod tests {
     fn create_instance() {
         let entry = Entry::linked();
         let _instance = Instance::new(&entry, None);
+    }
+
+    #[test]
+    fn create_physical_device() {
+        let entry = Entry::linked();
+        let instance = Instance::new(&entry, None);
+        let _physical_device = instance.create_physical_device_headless();
     }
 }
 

--- a/src/vulkan/instance.rs
+++ b/src/vulkan/instance.rs
@@ -205,7 +205,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn create_headless_instance() {
+    fn create_instance() {
         let entry = Entry::linked();
         let _instance = Instance::new(&entry, None);
     }

--- a/src/vulkan/surface.rs
+++ b/src/vulkan/surface.rs
@@ -1,3 +1,4 @@
+use ash::ext::headless_surface;
 use ash::khr::surface;
 use ash::vk;
 use ash::vk::{PresentModeKHR, SurfaceCapabilitiesKHR, SurfaceKHR};
@@ -9,12 +10,14 @@ use crate::vulkan::{Instance, LOG_TARGET};
 pub struct Surface {
     surface: SurfaceKHR,
     surface_loader: surface::Instance,
+    headless_surface: SurfaceKHR,
+    headless_loader: headless_surface::Instance,
 }
 
 impl Surface {
     pub fn new(entry: &ash::Entry, instance: &Instance, window: &WindowState ) -> Surface {
-        let surface_loader = surface::Instance::new(entry, instance.handle());
 
+        let surface_loader = surface::Instance::new(entry, instance.handle());
         let surface = unsafe {
             ash_window::create_surface(
                 entry,
@@ -25,11 +28,21 @@ impl Surface {
             ).expect("Failed to get surface.")
         };
 
+        let headless_loader = headless_surface::Instance::new(&entry, instance.handle());
+        let headless_surface = unsafe {
+            headless_loader.create_headless_surface(
+                &vk::HeadlessSurfaceCreateInfoEXT::default(),
+                None,
+            ).unwrap()
+        };
+
         trace!(target: LOG_TARGET, "Created surface: {:?}", surface);
 
         Surface {
             surface,
             surface_loader,
+            headless_surface,
+            headless_loader
         }
     }
 

--- a/src/vulkan/surface.rs
+++ b/src/vulkan/surface.rs
@@ -1,4 +1,3 @@
-use ash::ext::headless_surface;
 use ash::khr::surface;
 use ash::vk;
 use ash::vk::{PresentModeKHR, SurfaceCapabilitiesKHR, SurfaceKHR};
@@ -10,8 +9,6 @@ use crate::vulkan::{Instance, LOG_TARGET};
 pub struct Surface {
     surface: SurfaceKHR,
     surface_loader: surface::Instance,
-    headless_surface: SurfaceKHR,
-    headless_loader: headless_surface::Instance,
 }
 
 impl Surface {
@@ -28,21 +25,11 @@ impl Surface {
             ).expect("Failed to get surface.")
         };
 
-        let headless_loader = headless_surface::Instance::new(&entry, instance.handle());
-        let headless_surface = unsafe {
-            headless_loader.create_headless_surface(
-                &vk::HeadlessSurfaceCreateInfoEXT::default(),
-                None,
-            ).unwrap()
-        };
-
         trace!(target: LOG_TARGET, "Created surface: {:?}", surface);
 
         Surface {
             surface,
             surface_loader,
-            headless_surface,
-            headless_loader
         }
     }
 


### PR DESCRIPTION
Add lavapipe CI pipeline support
- Adds headless `PhysicalDevice` and `Instance` setup in order to support creation on CI pipelines.
- Adds basic `Instance`, `PhysicalDevice` and `Device` creation tests.